### PR TITLE
Kernel and irregular grid

### DIFF
--- a/jwst/extract_1d/soss_extract/engine_utils.py
+++ b/jwst/extract_1d/soss_extract/engine_utils.py
@@ -826,7 +826,8 @@ class WebbKernel:  # TODO could probably be cleaned-up somewhat, may need furthe
         #######################
 
         # Keep only kernels that fall on the detector.
-        kernels, wave_kernels = kernels[:, i_min:i_max + 1], wave_kernels[:, i_min:i_max + 1]
+        kernels = kernels[:, i_min:i_max + 1].copy()
+        wave_kernels = wave_kernels[:, i_min:i_max + 1].copy()
         wave_center = np.array(wave_kernels[0, :])
 
         # Save minimum kernel value (greater than zero)

--- a/jwst/extract_1d/soss_extract/soss_engine.py
+++ b/jwst/extract_1d/soss_extract/soss_engine.py
@@ -259,13 +259,25 @@ class _BaseOverlap:  # TODO Merge with TrpzOverlap?
 
     def update_kernels(self, kernels, c_kwargs):
 
-        # Verify the c_kwargs. TODO Be explict here?
-        # TODO Specify better default c_kwargs
+        # Check the c_kwargs inputs ...
+        # ...not given...
         if c_kwargs is None:
-            c_kwargs = [{} for _ in range(self.n_orders)]
+            # Then use the kernels min_value attribute.
+            # It is a way to make sure that the full kernel
+            # is used.
+            c_kwargs = []
+            for ker in kernels:
+                # If the min_value not specified, then
+                # simply take the get_c_matrix defaults
+                try:
+                    kwargs_ker = {'thresh': ker.min_value}
+                except AttributeError:
+                    kwargs_ker = dict()
+                c_kwargs.append(kwargs_ker)
 
+        # ...or same for each orders if only a dictionary was given
         elif isinstance(c_kwargs, dict):
-            c_kwargs = [c_kwargs for _ in range(self.n_orders)]
+            c_kwargs = [c_kwargs for _ in kernels]
 
         # Define convolution sparse matrix. TODO make dict with order number as key.
         kernels_new = []

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -71,7 +71,7 @@ def get_ref_file_args(ref_files, transform):
     wave_maps = [wavemap_o1, wavemap_o2]
     centroid = dict()
     for wv_map, order in zip(wave_maps, [1, 2]):
-        # Needs the same shape as the detector. Put zeros where not define.
+        # Needs the same number of columns as the detector. Put zeros where not define.
         wv_cent = np.zeros((1, wv_map.shape[1]))
         # Get central wavelength as a function of columns
         col, _, wv = get_trace_1d(ref_files, transform, order)

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -66,8 +66,24 @@ def get_ref_file_args(ref_files, transform):
     ovs = speckernel_ref.meta.spectral_oversampling
     n_pix = 2*speckernel_ref.meta.halfwidth + 1
 
-    kernels_o1 = WebbKernel(speckernel_ref.wavelengths, speckernel_ref.kernels, wavemap_o1, ovs, n_pix)
-    kernels_o2 = WebbKernel(speckernel_ref.wavelengths, speckernel_ref.kernels, wavemap_o2, ovs, n_pix)
+    # Take the centroid of each trace as a grid to project the WebbKernel
+    # WebbKer needs a 2d input, so artificially add axis
+    wave_maps = [wavemap_o1, wavemap_o2]
+    centroid = dict()
+    for wv_map, order in zip(wave_maps, [1, 2]):
+        # Needs the same shape as the detector. Put zeros where not define.
+        wv_cent = np.zeros((1, wv_map.shape[1]))
+        # Get central wavelength as a function of columns
+        col, _, wv = get_trace_1d(ref_files, transform, order)
+        wv_cent[:, col] = wv
+        # Set invalid values to zero
+        idx_invalid = ~np.isfinite(wv_cent)
+        wv_cent[idx_invalid] = 0.0
+        centroid[order] = wv_cent
+
+    # Get kernels
+    kernels_o1 = WebbKernel(speckernel_ref.wavelengths, speckernel_ref.kernels, centroid[1], ovs, n_pix)
+    kernels_o2 = WebbKernel(speckernel_ref.wavelengths, speckernel_ref.kernels, centroid[2], ovs, n_pix)
 
     return [wavemap_o1, wavemap_o2], [specprofile_o1, specprofile_o2], [throughput_o1, throughput_o2], [kernels_o1, kernels_o2]
 


### PR DESCRIPTION
About convolution kernels: Use the solution given by `get_trace_1d` to estimate the pixel wavelength in 1D instead of using the 2d map. Add a threshold to WebbKernel, so it is easier to make sure that the whole kernel is used when building the convolution matrix.

About irregular grid: New way to define the grid use to model and extract the detector. Use an irregular grid based on the estimate of the spectrum. The grid will have a finer sampling on the parts of the spectrum where it's necessary. 