### PR TITLE
Solver Compatibility with F277 and SUBSTRIP96

### DIFF
--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -204,7 +204,7 @@ def estim_flux_first_order(scidata_bkg, scierr, scimask, ref_files, threshold):
 
 
 def model_image(scidata_bkg, scierr, scimask, refmask, ref_files, transform=None,
-                tikfac=None, n_os=5, threshold=1e-4, devname=None):
+                tikfac=None, n_os=5, threshold=1e-4, devname=None, soss_filter='CLEAR'):
     """Perform the spectral extraction on a single image.
 
     :param scidata_bkg: A single background subtracted NIRISS SOSS detector image.
@@ -254,7 +254,8 @@ def model_image(scidata_bkg, scierr, scimask, refmask, ref_files, transform=None
         yref_o2 = spectrace_ref.trace[1].data['Y']
 
         # Use the solver on the background subtracted image.
-        transform = solve_transform(scidata_bkg, scimask, xref_o1, yref_o1, xref_o2, yref_o2)
+        transform = solve_transform(scidata_bkg, scimask, xref_o1, yref_o1,
+                                    xref_o2, yref_o2, soss_filter=soss_filter)
 
     log.info('Using transformation parameters {}'.format(transform))
 
@@ -633,6 +634,9 @@ def run_extract1d(input_model: DataModel,
                 # Some assumption for the transform is required. Ideally, applying that of the CLEAR
                 # exposure. But that would mean linking two exposures... That is not currently our
                 # structure.
+                # MCR - solve_transform now takes a soss_filter argument, which if set to 'F277W'
+                # will allow the solver to handle an F277W. I have added a soss_filter kwarg to
+                # model_image to pass along this info to the solver
                 #    model_image returns: tracemodels, transform, tikfac, logl
                 soss_kwargs['transform'] = [0,0,0]
 

--- a/jwst/extract_1d/soss_extract/soss_solver.py
+++ b/jwst/extract_1d/soss_extract/soss_solver.py
@@ -231,7 +231,7 @@ def _chi_squared_shift(transform, xref_o1, yref_o1, xref_o2, yref_o2,
 
 
 def solve_transform(scidata_bkg, scimask, xref_o1, yref_o1, xref_o2=None,
-                    yref_o2 = None, halfwidth=30., rotation=True, shift=True,
+                    yref_o2=None, halfwidth=30., rotation=True, shift=True,
                     soss_filter='CLEAR', verbose=False):
     """Given a science image, determine the centroids and find the simple
     transformation needed to match xref_o1 and yref_o1 to the image.
@@ -263,7 +263,7 @@ def solve_transform(scidata_bkg, scimask, xref_o1, yref_o1, xref_o2=None,
         rotation angle.
     soss_filter : str (optional)
         Designator for the SOSS filter used in the observation. Either CLEAR
-        or F277W. Setting F277W here will force rotation to False.
+        or F277W. Setting F277W here will force shift to False.
     verbose : bool (optional)
         If True make a diagnostic image of the best-fit transformation.
 
@@ -320,9 +320,9 @@ def solve_transform(scidata_bkg, scimask, xref_o1, yref_o1, xref_o2=None,
         mask = (xdat_o1 >= 25) & (xdat_o1 <= 425)
         xdat_o1 = xdat_o1[mask]
         ydat_o1 = ydat_o1[mask]
-        # Force rotation to False as there is not enough information to
+        # Force shift to False as there is not enough information to
         # constrain dx, dy and dtheta simultaneously.
-        #rotation = False
+        shift = False
         # Second order centroids are not available.
         xdat_o2, ydat_o2 = None, None
     else:
@@ -343,6 +343,7 @@ def solve_transform(scidata_bkg, scimask, xref_o1, yref_o1, xref_o2=None,
 
         simple_transform = np.zeros(3)
         simple_transform[1:] = result.x
+
     elif shift is False:
         # If not considering horizontal or vertical shifts.
         # Set up the optimization problem.
@@ -355,6 +356,7 @@ def solve_transform(scidata_bkg, scimask, xref_o1, yref_o1, xref_o2=None,
 
         simple_transform = np.zeros(3)
         simple_transform[0] = result.x
+
     else:
         # If considering the full transformation.
         # Set up the optimization problem.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title
starts with the JIRA issue number, for example
JP-1234: <Fix a bug>
-->

Closes #27 
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

**Description**

Update Solver to add compatibility with the F277W filter, and address issue where bizarrely large offsets were being returned for SUBSTRIP96 exposures. 

Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Change log
- [ ] Milestone
- [ ] Label(s)
